### PR TITLE
Update Dockerfile to Ubuntu 24.04 and runner version 2.331.0, and updated README.md for the `REPO` env.

### DIFF
--- a/Docker Image/Dockerfile
+++ b/Docker Image/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
-ARG RUNNER_VERSION="2.317.0"
+ARG RUNNER_VERSION="2.331.0"
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Update and upgrade the system

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Welcome to the GitHub Self-Hosted Runner Dockerization repository. This project 
 
 ### Environment Variables
 
-- `REPO`: The GitHub repository to register the runner to (format: `<owner>/<repo>`).
+- `REPO`: The GitHub repository to register the runner to (format: `<owner>/<repo>`). It can also be set to an organization instead of a repository (format: `<owner>`).
 - `REG_TOKEN`: The registration token for the self-hosted runner from the GitHub repository settings.
 - `NAME`: The name of the self-hosted runner.
 


### PR DESCRIPTION
Update Dockerfile to Ubuntu 24.04 and runner version 2.331.0, because the old version of git which is shipped with ubuntu 20.04 doesn't work good with some of the actions.

Updated README.md to clarify that the `REPO` env variable can be used for an organization as well.