### PR TITLE
feat: configurable runner options via environment variables (v1.2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,30 @@
 # GitHub Self-Hosted Runner Environment Variables
 # Copy this file to .env and fill in the values
 
-# The GitHub repository to register the runner to (format: <owner>/<repo>)
-# Can also be set to an organization instead of a repository (format: <owner>)
+# --- Required ---
+
+# GitHub repository (format: <owner>/<repo>) or organization (format: <owner>)
 REPO=<owner>/<repo>
 
-# The registration token for the self-hosted runner from the GitHub repository settings
-# Generate at: https://github.com/<owner>/<repo>/settings/actions/runners/new
+# Registration token from: https://github.com/<owner>/<repo>/settings/actions/runners/new
 REG_TOKEN=your_registration_token_here
 
-# The name of the self-hosted runner
+# Display name for this runner
 NAME=my-runner
+
+# --- Optional ---
+
+# Comma-separated labels to tag this runner (e.g. self-hosted,linux,x64,gpu)
+# LABELS=self-hosted,linux,x64
+
+# Runner group name (org/enterprise only)
+# RUNNER_GROUP=default
+
+# Custom workspace directory inside the container
+# WORK_DIR=_work
+
+# Set to "true" to register as ephemeral — runner deregisters after one job
+# EPHEMERAL=false
+
+# Set to "true" to prevent the runner from auto-updating itself
+# DISABLE_AUTO_UPDATE=false

--- a/README.md
+++ b/README.md
@@ -123,9 +123,31 @@ Welcome to the GitHub Self-Hosted Runner Dockerization repository. This project 
 
 ### Environment Variables
 
-- `REPO`: The GitHub repository to register the runner to (format: `<owner>/<repo>`). It can also be set to an organization instead of a repository (format: `<owner>`).
-- `REG_TOKEN`: The registration token for the self-hosted runner from the GitHub repository settings.
-- `NAME`: The name of the self-hosted runner.
+**Required**
+
+| Variable | Description |
+|----------|-------------|
+| `REPO` | Repository (`<owner>/<repo>`) or organization (`<owner>`) to register the runner to. |
+| `REG_TOKEN` | Registration token from GitHub → Settings → Actions → Runners → "New self-hosted runner". Expires after 1 hour. |
+| `NAME` | Display name for this runner. |
+
+**Optional**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LABELS` | _(none)_ | Comma-separated labels, e.g. `self-hosted,linux,x64,gpu`. |
+| `RUNNER_GROUP` | _(default group)_ | Runner group name — org/enterprise only. |
+| `WORK_DIR` | `_work` | Custom workspace directory inside the container. |
+| `EPHEMERAL` | `false` | Set to `true` to deregister the runner after one job completes. |
+| `DISABLE_AUTO_UPDATE` | `false` | Set to `true` to prevent the runner from auto-updating. |
+
+### Custom Runner Version
+
+Override the runner version at build time without editing the Dockerfile:
+
+```sh
+docker build --build-arg RUNNER_VERSION=2.332.0 -t custom-github-runner:latest ./docker/linux
+```
 
 ## Notes for macOS Users
 

--- a/docker/linux/start.sh
+++ b/docker/linux/start.sh
@@ -6,7 +6,15 @@
 
 cd /home/docker/actions-runner || exit
 
-./config.sh --url https://github.com/${REPO} --token ${REG_TOKEN} --name ${NAME}
+CONFIG_ARGS="--url https://github.com/${REPO} --token ${REG_TOKEN} --name ${NAME}"
+
+[ -n "${LABELS}" ]       && CONFIG_ARGS="${CONFIG_ARGS} --labels ${LABELS}"
+[ -n "${RUNNER_GROUP}" ] && CONFIG_ARGS="${CONFIG_ARGS} --runnergroup ${RUNNER_GROUP}"
+[ -n "${WORK_DIR}" ]     && CONFIG_ARGS="${CONFIG_ARGS} --work ${WORK_DIR}"
+[ "${EPHEMERAL}" = "true" ]            && CONFIG_ARGS="${CONFIG_ARGS} --ephemeral"
+[ "${DISABLE_AUTO_UPDATE}" = "true" ]  && CONFIG_ARGS="${CONFIG_ARGS} --disableupdate"
+
+./config.sh ${CONFIG_ARGS}
 
 cleanup() {
   echo "Removing runner..."

--- a/docker/mac/start.sh
+++ b/docker/mac/start.sh
@@ -6,7 +6,15 @@
 
 cd /home/runner/actions-runner || exit
 
-./config.sh --url https://github.com/${REPO} --token ${REG_TOKEN} --name ${NAME}
+CONFIG_ARGS="--url https://github.com/${REPO} --token ${REG_TOKEN} --name ${NAME}"
+
+[ -n "${LABELS}" ]       && CONFIG_ARGS="${CONFIG_ARGS} --labels ${LABELS}"
+[ -n "${RUNNER_GROUP}" ] && CONFIG_ARGS="${CONFIG_ARGS} --runnergroup ${RUNNER_GROUP}"
+[ -n "${WORK_DIR}" ]     && CONFIG_ARGS="${CONFIG_ARGS} --work ${WORK_DIR}"
+[ "${EPHEMERAL}" = "true" ]            && CONFIG_ARGS="${CONFIG_ARGS} --ephemeral"
+[ "${DISABLE_AUTO_UPDATE}" = "true" ]  && CONFIG_ARGS="${CONFIG_ARGS} --disableupdate"
+
+./config.sh ${CONFIG_ARGS}
 
 cleanup() {
   echo "Removing runner..."


### PR DESCRIPTION
- Add LABELS env var — pass custom runner labels to config.sh
- Add RUNNER_GROUP env var — register runner into a specific org/enterprise group
- Add WORK_DIR env var — override default workspace directory
- Add EPHEMERAL env var — run once then auto-deregister (--ephemeral)
- Add DISABLE_AUTO_UPDATE env var — prevent runner self-updates
- Update .env.example with all optional vars, commented out with defaults
- Update README: full env var reference table, custom version build-arg docs