### PR TITLE
ci(docker): add linux image publish workflow and improve Dockerfile

### DIFF
--- a/.github/workflows/publish-linux-image.yml
+++ b/.github/workflows/publish-linux-image.yml
@@ -1,0 +1,50 @@
+name: Publish Linux Image
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
+jobs:
+  publish:
+    name: Build and publish linux image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+
+      - name: Build and publish
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/linux
+          file: docker/linux/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ docker-compose -f docker/mac/docker-compose.yml up -d
 - **Scalable** — Linux defaults to 2 replicas; tune with `deploy.replicas`
 - **Ephemeral mode** — run once and self-destruct (`EPHEMERAL=true`)
 - **Docker-in-Docker** — macOS image mounts the Docker socket for nested builds
+- **GitHub CLI** — `gh` pre-installed from official repos on both variants
+- **Docker CLI** — official Docker CE CLI with buildx and compose plugins
 - **Healthchecks** — built-in `pgrep run.sh` health monitoring on both variants
 
 ---
@@ -134,6 +136,19 @@ deploy:
       cpus: '0.5'
       memory: 512M
 ```
+
+---
+
+## Publishing Images
+
+A GitHub Actions workflow automatically builds and publishes the Linux Docker image to GHCR on version tag pushes (`v*`).
+
+```sh
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+The image is published to `ghcr.io/<owner>/self-hosted-runner:<tag>`.
 
 ---
 

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -9,11 +9,19 @@ RUN apt update -y && apt upgrade -y && rm -rf /var/lib/apt/lists/*
 # Add a user named docker
 RUN useradd -m docker
 
-# Install necessary packages
-RUN apt-get update && apt install -y --no-install-recommends \
-    curl git build-essential libssl-dev libffi-dev python3 python3-venv python3-dev python3-pip jq \
-    sudo docker.io \
-    && apt-get -yqq install ssh \
+# Install necessary packages, GitHub CLI, and Docker CLI
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl gnupg \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "${VERSION_CODENAME}") stable" > /etc/apt/sources.list.d/docker.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+    build-essential docker-buildx-plugin docker-ce-cli docker-compose-plugin gh git jq libffi-dev libssl-dev \
+    python3 python3-dev python3-pip python3-venv ssh sudo \
     && rm -rf /var/lib/apt/lists/*
 
 # Add docker user to docker group and allow GID fix at startup


### PR DESCRIPTION
- Add GitHub Actions workflow to build and publish linux image on tag push
- Install GitHub CLI and Docker CLI from official repositories in Dockerfile
- Consolidate package installation with proper apt key management
- Update README with new features and publishing docs