### PR TITLE
fix(docker): use pre-built GHCR image in linux compose and document both options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,21 @@ docker-compose -f docker/linux/docker-compose.yml up -d
 docker-compose -f docker/mac/docker-compose.yml up -d
 ```
 
-> **REG_TOKEN expires after 1 hour.** Generate a fresh one from  
+> **REG_TOKEN expires after 1 hour.** Generate a fresh one from
 > GitHub → Settings → Actions → Runners → "New self-hosted runner" before each deploy.
+
+---
+
+## Pre-built Image vs Local Build
+
+**Linux (x64)** supports both options. By default, `docker-compose up` pulls the pre-built image from GHCR — no build step required.
+
+| Mode | How | When to use |
+|------|-----|-------------|
+| **Pre-built** (default) | Just run `docker-compose up` | Quick setup, no customization needed |
+| **Local build** | Uncomment `build: .` in `docker/linux/docker-compose.yml` | Custom Dockerfile changes, runner version overrides |
+
+**macOS / ARM64** builds locally only (no pre-built image available yet).
 
 ---
 

--- a/docker/linux/docker-compose.yml
+++ b/docker/linux/docker-compose.yml
@@ -1,7 +1,8 @@
 services:
   runner:
-    build: .
-    image: youssefbrr/github-actions:latest # You can use this image or build your own
+    image: ghcr.io/youssefbrr/self-hosted-runner:latest
+    # Uncomment to build locally instead of pulling from GHCR
+    # build: .
     restart: always
     env_file:
       - ../../.env


### PR DESCRIPTION
- Set image to ghcr.io/youssefbrr/self-hosted-runner:latest
- Comment out build: . for users who want to build locally
- Add Pre-built Image vs Local Build section to README