### PR TITLE
ci(docker): add mac image publish workflow and use GHCR in compose

### DIFF
--- a/.github/workflows/publish-mac-image.yml
+++ b/.github/workflows/publish-mac-image.yml
@@ -1,0 +1,51 @@
+name: Publish Mac Image
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
+jobs:
+  publish:
+    name: Build and publish mac image
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest-arm64
+            type=ref,event=tag,suffix=-arm64
+
+      - name: Build and publish
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/mac
+          file: docker/mac/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -32,14 +32,17 @@ docker-compose -f docker/mac/docker-compose.yml up -d
 
 ## Pre-built Image vs Local Build
 
-**Linux (x64)** supports both options. By default, `docker-compose up` pulls the pre-built image from GHCR — no build step required.
+Both variants support pre-built images from GHCR. By default, `docker-compose up` pulls the pre-built image — no build step required.
+
+| Variant | Image | Tag |
+|---------|-------|-----|
+| **Linux (x64)** | `ghcr.io/youssefbrr/self-hosted-runner` | `latest` |
+| **macOS / ARM64** | `ghcr.io/youssefbrr/self-hosted-runner` | `latest-arm64` |
 
 | Mode | How | When to use |
 |------|-----|-------------|
 | **Pre-built** (default) | Just run `docker-compose up` | Quick setup, no customization needed |
-| **Local build** | Uncomment `build: .` in `docker/linux/docker-compose.yml` | Custom Dockerfile changes, runner version overrides |
-
-**macOS / ARM64** builds locally only (no pre-built image available yet).
+| **Local build** | Uncomment `build: .` in the compose file | Custom Dockerfile changes, runner version overrides |
 
 ---
 
@@ -154,14 +157,17 @@ deploy:
 
 ## Publishing Images
 
-A GitHub Actions workflow automatically builds and publishes the Linux Docker image to GHCR on version tag pushes (`v*`).
+GitHub Actions workflows automatically build and publish both images to GHCR on version tag pushes (`v*`).
 
 ```sh
 git tag v1.0.0
 git push origin v1.0.0
 ```
 
-The image is published to `ghcr.io/<owner>/self-hosted-runner:<tag>`.
+| Image | Tag | Platform |
+|-------|-----|----------|
+| `ghcr.io/<owner>/self-hosted-runner` | `latest` / `v1.0.0` | linux/amd64 |
+| `ghcr.io/<owner>/self-hosted-runner` | `latest-arm64` / `v1.0.0-arm64` | linux/arm64 |
 
 ---
 

--- a/docker/mac/docker-compose.yml
+++ b/docker/mac/docker-compose.yml
@@ -1,7 +1,8 @@
 services:
   runner:
-    build: .
-    image: custom-github-runner-mac:latest
+    image: ghcr.io/youssefbrr/self-hosted-runner:latest-arm64
+    # Uncomment to build locally instead of pulling from GHCR
+    # build: .
     platform: linux/arm64
     restart: always
     env_file:


### PR DESCRIPTION
- Add GitHub Actions workflow to build and publish mac/arm64 image on tag push
- Use ubuntu-24.04-arm runner for native ARM64 builds
- Update docker/mac/docker-compose.yml to pull from GHCR by default
- Update README with mac pre-built image documentation