### PR TITLE
Add dependencies to arm image

### DIFF
--- a/docker/mac/Dockerfile
+++ b/docker/mac/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y \
     zlib1g \
     iputils-ping \
     openssh-client \
+    build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 # Add runner user to docker group and allow GID fix at startup


### PR DESCRIPTION
Needed to add build-essential otherwise buildx and cargo will fail during workflows due to not having a cc-linker